### PR TITLE
Remove inheritance from FluidSynthSequencer for Piano class

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Pyano
 
-Pyano is a python package to programmatically play piano. It is an easy to use abstraction layer on top of the
-[python-mingus](http://bspaans.github.io/python-mingus/index.html) package providing a simple to use interface to play mingus music containers, such as Notes,
+Pyano is a python library to programmatically play piano. It is an easy-to-use abstraction layer on top of the
+[python-mingus](http://bspaans.github.io/python-mingus/index.html) package providing a simple user interface to play mingus music containers, such as Notes,
 NoteContainers, Bars and Tracks. It bundles a default sound fonts file to enable playing and recording audio out
-of the box with. By default 8 different pianos are available. It allows to play Piano via audio output or recording music to wav files.
+of the box. By default, 8 different pianos are available. It allows playing Piano via audio output or recording music to wav files.
 
 ## Installation
 

--- a/pyano/keyboard.py
+++ b/pyano/keyboard.py
@@ -292,6 +292,10 @@ class PianoKeyboard(object):
         return set(available_keys)
 
     @property
+    def keys(self) -> Dict[int, PianoKey]:
+        return self._keyboard
+
+    @property
     def white_keys(self) -> Dict[int, PianoKey]:
         """Return a sub dictionary of all black keys from keyboard"""
         return {key: piano_key for key, piano_key in self._keyboard.items() if "white" in piano_key.key_color}

--- a/pyano/piano.py
+++ b/pyano/piano.py
@@ -98,22 +98,6 @@ class Piano(object):
         # Initialize a piano keyboard
         self.keyboard = PianoKeyboard()
 
-    def _unload_sound_fonts(self) -> None:
-        """Unload a given sound font file
-
-        Safely unload current sound font file. Method controls if a sound font file is already loaded via
-        self._sound_fonts_loaded.
-        """
-
-        logger.debug("Unloading current active sound fonts from file: {0}".format(self._sound_fonts_path))
-
-        if self._sound_fonts_loaded:
-            self.__fluid_synth_sequencer.fs.sfunload(self.__fluid_synth_sequencer.sfid)
-        else:
-            logger.debug("No active sound fonts")
-
-        self._sound_fonts_path = None
-
     def load_sound_fonts(self, sound_fonts_path: Union[str, Path]) -> None:
         """Load sound fonts from a given path"""
         logger.debug("Attempting to load sound fonts from {file}".format(file=sound_fonts_path))
@@ -129,6 +113,22 @@ class Piano(object):
         self._sound_fonts_path = Path(sound_fonts_path)
 
         logger.debug("Successfully initialized sound fonts from {file_path}".format(file_path=sound_fonts_path))
+
+    def _unload_sound_fonts(self) -> None:
+        """Unload a given sound font file
+
+        Safely unload current sound font file. Method controls if a sound font file is already loaded via
+        self._sound_fonts_loaded.
+        """
+
+        logger.debug("Unloading current active sound fonts from file: {0}".format(self._sound_fonts_path))
+
+        if self._sound_fonts_loaded:
+            self.__fluid_synth_sequencer.fs.sfunload(self.__fluid_synth_sequencer.sfid)
+            self._sound_fonts_loaded = False
+            self._sound_fonts_path = None
+        else:
+            logger.debug("No active sound fonts")
 
     def _start_audio_output(self) -> None:
         """Private method to start audio output
@@ -224,6 +224,9 @@ class Piano(object):
             self.instrument = instrument
 
         else:
+
+            if isinstance(instrument, str):
+                raise TypeError("When using non default sound fonts you must pass an integer for instrument parameter")
 
             self.__fluid_synth_sequencer.set_instrument(channel=1, instr=instrument, bank=0)
             self.instrument = instrument

--- a/pyano/piano.py
+++ b/pyano/piano.py
@@ -279,6 +279,18 @@ class Piano(object):
 
             self.__fluid_synth_sequencer.wav.close()
 
+            # It seems we have to delete the wav attribute after recording in order to enable switching between
+            # audio output and recording for all music containers. The
+            # mingus.midi.fluidsynth.FluidSynthSequencer.play_Bar and
+            # mingus.midi.fluidsynth.FluidSynthSequencer.play_Track use the
+            # mingus.midi.fluidsynth.FluidSynthSequencer.sleep methods internally which is for some reason also used
+            # to record in mingus.
+            # See also my issue in the mingus repository: https://github.com/bspaans/python-mingus/issues/77
+            # When wav attribute is present sleep tries to write to the wave file and if not the method just sleeps.
+            # If we do not delete the wav attribute it is still there as None and play_Bar tries to write to the file
+            # resulting in AttributeError: 'NoneType' object has no attribute 'write'
+            delattr(self.__fluid_synth_sequencer, "wav")
+
             logger.info("Finished recording to {recording_file}".format(recording_file=recording_file))
 
     def _play_music_container(

--- a/scripts/get_default_sf_file.py
+++ b/scripts/get_default_sf_file.py
@@ -105,11 +105,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-
-
-from sf2utils.sf2parse import Sf2File
-
-with open("./pyano/sound_fonts/FluidR3_GM.sf2", "rb") as sf2_file:
-    sf2 = Sf2File(sf2_file)
-
-len(sf2.instruments)

--- a/tests/mock_objects.py
+++ b/tests/mock_objects.py
@@ -1,0 +1,51 @@
+class MockSynth(object):
+    def __init__(self):
+        self.audio_driver = None
+
+    def sfunload(self, sfid):
+        return True
+
+    def program_reset(self):
+        return True
+
+    def get_samples(self, len):
+        return True
+
+
+class MockWav(object):
+    def writeframes(self, data):
+        return True
+
+    def close(self):
+        return True
+
+
+class MockFluidSynthSequencer(object):
+    def __init__(self):
+        self.fs = MockSynth()
+        self.sfid = None
+        self.wav = MockWav()
+
+    def load_sound_font(self, path):
+        return True
+
+    def start_audio_output(self, driver):
+        return True
+
+    def set_instrument(self, channel, instr, bank):
+        return True
+
+    def start_recording(self, file):
+        return True
+
+    def play_Note(self, note):
+        return True
+
+    def play_NoteContainer(self, nc):
+        return True
+
+    def play_Bar(self, bar):
+        return True
+
+    def play_Track(self, track):
+        return True

--- a/tests/test_keyboard.py
+++ b/tests/test_keyboard.py
@@ -9,8 +9,8 @@ class KeyboardTests(unittest.TestCase):
     def setUp(self) -> None:
         self.keyboard = PianoKeyboard()
 
-    def test_init_keyboard(self):
-        self.assertEqual(len(PianoKeyboard._create_keyboard_dict()), 88)
+    def test_keys(self):
+        self.assertEqual(len(self.keyboard.keys), 88)
 
     def test_white_keys(self):
         self.assertEqual(len(self.keyboard.white_keys), 52)

--- a/tests/test_piano.py
+++ b/tests/test_piano.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+import unittest
+from unittest.mock import patch
+from pyano import piano
+from pathlib import Path
+from .mock_objects import MockFluidSynthSequencer
+from mingus.containers import Note, NoteContainer, Bar, Track
+
+
+@patch("pyano.piano.FluidSynthSequencer", return_value=MockFluidSynthSequencer())
+class PianoTests(unittest.TestCase):
+    """Basic test cases."""
+
+    def test_load_sound_fonts(self, mock_fluid_synth_sequencer) -> None:
+        p = piano.Piano()
+        new_sf_path = "/fantasypath/fantasyfile.sf2"
+
+        p._sound_fonts_loaded = True
+        p.load_sound_fonts(new_sf_path)
+        self.assertEqual(p._sound_fonts_loaded, True)
+        self.assertEqual(p._sound_fonts_path, Path(new_sf_path))
+
+        p._sound_fonts_loaded = False
+        p.load_sound_fonts(new_sf_path)
+        self.assertEqual(p._sound_fonts_loaded, True)
+        self.assertEqual(p._sound_fonts_path, Path(new_sf_path))
+
+    def test_unload_sound_fonts(self, mock_fluid_synth_sequencer) -> None:
+        p = piano.Piano()
+        self.assertEqual(p._sound_fonts_loaded, True)
+        self.assertNotEqual(p._sound_fonts_loaded, None)
+
+        p._unload_sound_fonts()
+        self.assertEqual(p._sound_fonts_loaded, False)
+        self.assertEqual(p._sound_fonts_path, None)
+
+    def test_start_audio_output(self, mock_fluid_synth_sequencer) -> None:
+        p = piano.Piano()
+
+        # Start with empty audio driver
+        self.assertEqual(p._audio_driver_is_active, False)
+        p._start_audio_output()
+        self.assertEqual(p._audio_driver_is_active, True)
+        # Check for idempotency
+        p._start_audio_output()
+        self.assertEqual(p._audio_driver_is_active, True)
+
+        p._current_audio_driver = "SomeFantasyDriverName"
+        self.assertRaises(ValueError, p._start_audio_output)
+
+    @patch("pyano.piano.globalfs.delete_fluid_audio_driver", return_value=None)
+    def test_stop_audio_output(self, mock_fluid_synth_sequencer, mock_delete_fluid_audio_driver) -> None:
+        p = piano.Piano()
+        # Start with empty audio driver
+        self.assertEqual(p._audio_driver_is_active, False)
+        # Check that p._audio_driver_is_active is still False after calling it again
+        p._stop_audio_output()
+        self.assertEqual(p._audio_driver_is_active, False)
+
+        p._audio_driver_is_active = True
+        p._stop_audio_output()
+        self.assertEqual(p._audio_driver_is_active, False)
+
+    def test_load_instrument(self, mock_fluid_synth_sequencer) -> None:
+        p = piano.Piano()
+
+        self.assertRaises(TypeError, p.load_instrument, instrument=1)
+        self.assertRaises(ValueError, p.load_instrument, instrument="FantasyInstrument")
+        new_instrument = "Bright Acoustic Piano"
+        p.load_instrument(instrument=new_instrument)
+        self.assertEqual(p.instrument, new_instrument)
+
+        # Test cases for non default sound fonts
+        p._sound_fonts_path = "/fantasypath/fantasyfile.sf2"
+        self.assertRaises(TypeError, p.load_instrument, instrument=new_instrument)
+
+        new_instrument = 1
+        p.load_instrument(instrument=new_instrument)
+        self.assertEqual(p.instrument, new_instrument)
+
+    @patch("pyano.piano.globalfs.raw_audio_string", return_value=1)
+    def test_play(self, mock_fluid_synth_sequencer, mock_raw_audio_string):
+
+        p = piano.Piano()
+
+        p.play("C-4", recording_file=None)
+        self.assertEqual(p._audio_driver_is_active, True)
+
+        p.play("C-4", recording_file="test.wav")
+        self.assertEqual(p._audio_driver_is_active, False)
+
+    def test_lint_music_container(self, mock_fluid_synth_sequencer):
+
+        p = piano.Piano()
+        outside_left = Note("G-0")
+        outside_right = Note("D-8")
+        self.assertRaises(ValueError, p._lint_music_container, music_container=outside_left)
+        self.assertRaises(ValueError, p._lint_music_container, music_container=outside_right)
+
+        note_container = NoteContainer([outside_left, outside_left])
+        self.assertRaises(ValueError, p._lint_music_container, music_container=note_container)
+
+        bar = Bar()
+        bar.place_notes([outside_left, outside_right], 2)
+        self.assertRaises(ValueError, p._lint_music_container, music_container=bar)
+
+        track = Track()
+        track.add_bar(bar)
+        self.assertRaises(ValueError, p._lint_music_container, music_container=track)


### PR DESCRIPTION
Remove inheritance from FluidSynthSequencer for Piano class in order to hide its' methods from users, because they are not intended to be used with this package